### PR TITLE
Log rotation for service access logs

### DIFF
--- a/mwms/nginx/init.sls
+++ b/mwms/nginx/init.sls
@@ -6,3 +6,4 @@
 
 include:
   - .install
+  - .logrotate

--- a/mwms/nginx/logrotate.sls
+++ b/mwms/nginx/logrotate.sls
@@ -16,6 +16,6 @@
           notifempty
           create 0640 www-data adm
           postrotate
-		        invoke-rc.d nginx rotate >/dev/null 2>&1
+            invoke-rc.d nginx rotate >/dev/null 2>&1
           endscript
         }

--- a/mwms/nginx/logrotate.sls
+++ b/mwms/nginx/logrotate.sls
@@ -1,0 +1,21 @@
+# Copyright (c) 2015 Martin Helmich <m.helmich@mittwald.de>
+#                    Mittwald CM Service GmbH & Co. KG
+#
+# Docker-based microservice deployment with service discovery
+# This code is MIT-licensed. See the LICENSE.txt for more information
+
+/etc/logrotate.d/services:
+  file.managed:
+    - contents: |
+        var/log/services/*/access.log {
+          daily
+          missingok
+          rotate 30
+          compress
+          delaycompress
+          notifempty
+          create 0640 www-data adm
+          postrotate
+		        invoke-rc.d nginx rotate >/dev/null 2>&1
+          endscript
+        }


### PR DESCRIPTION
After #12, centralized access logs for all services are written to `/var/log/services/<service-name>/access.log`.

This PR introduces a logrotate configuration for automatically rotating these logs.
