### PR TITLE
[FEATURE] Recreate all container with "volume_from" configuration on redeploy

### DIFF
--- a/_modules/microservice.py
+++ b/_modules/microservice.py
@@ -66,7 +66,8 @@ def redeploy(service_name, tag_override='latest'):
 
             if used_image_id == current_image_id:
                 result["container_ids"][container_name]["new"] = result["container_ids"][container_name]["old"]
-                continue
+                if 'volumes_from' not in container_config:
+                    continue
 
             if existing_container_info is not None:
                 if 'stateful' in container_config and container_config['stateful']:


### PR DESCRIPTION
With the current redeploy function containers with a "volumes_from" configuration will be broken if the providing container is recreated, but not the receiving one.
